### PR TITLE
action_from_trackpad_instead_of_menu

### DIFF
--- a/launch/g1_dual.launch.py
+++ b/launch/g1_dual.launch.py
@@ -63,12 +63,14 @@ def generate_launch_description():
 
             # --- MANUAL BUTTON TOPIC MAPPING (LEFT) ---
             'trigger_topic': '/vive/left/trigger',
-            'trackpad_x_topic': '/vive/left/trackpad_x',
+            # 'trackpad_x_topic': '/vive/left/trackpad_x',
+            'trackpad_x_topic': '/g1pilot/left_hand/dx3/action',
             'trackpad_y_topic': '/vive/left/trackpad_y',
             'grip_topic': '/vive/left/grip',
-            'menu_topic': '/g1pilot/left_hand/dx3/action',
+            'menu_topic': '/vive/left/menu',
             'trackpad_touched_topic': '/vive/left/trackpad_touched',
             'trackpad_pressed_topic': '/vive/left/trackpad_pressed',
+            'trackpad_pressed_required' : 'true'  # Only publish when trackpad is pressed
         }]
     )
 
@@ -88,12 +90,14 @@ def generate_launch_description():
 
             # --- MANUAL BUTTON TOPIC MAPPING (RIGHT) ---
             'trigger_topic': '/vive/right/trigger',
-            'trackpad_x_topic': '/vive/right/trackpad_x',
+            # 'trackpad_x_topic': '/vive/right/trackpad_x',
             'trackpad_y_topic': '/vive/right/trackpad_y',
+            'trackpad_x_topic': '/g1pilot/right_hand/dx3/action',
             'grip_topic': '/vive/right/grip',
-            'menu_topic': '/g1pilot/right_hand/dx3/action',
+            'menu_topic': '/vive/right/menu',
             'trackpad_touched_topic': '/vive/right/trackpad_touched',
             'trackpad_pressed_topic': '/vive/right/trackpad_pressed',
+            'trackpad_pressed_required' : 'true'  # 
         }]
     )
 

--- a/ros2_vive_controller/teleop_bridge_node.py
+++ b/ros2_vive_controller/teleop_bridge_node.py
@@ -18,6 +18,7 @@ class TeleopBridgeNode(Node):
         self.declare_parameter('publish_frequency', 30.0)
         self.declare_parameter('target_frame', 'base_link')
         self.declare_parameter('reference_frame', 'world')
+        self.declare_parameter('trackpad_pressed_required', 'false')
 
         self.button_keys = [
             'trigger', 'trackpad_x', 'trackpad_y',
@@ -49,7 +50,7 @@ class TeleopBridgeNode(Node):
         self.prev_button_state = None
         self.activated = False
         self.last_output_msg = None
-
+        self.trackpad_pressed_required = self.get_parameter('trackpad_pressed_required').value.lower() == 'true'
         # --- 4. Subscribers ---
         self.pose_sub = self.create_subscription(
             PoseStamped, self.get_parameter('pose_topic').value, self.pose_callback, 10)
@@ -71,7 +72,10 @@ class TeleopBridgeNode(Node):
         timestamp = self.get_clock().now().to_msg()
         for key, pub in self.button_pubs.items():
             if key in button_data:
-                val = float(button_data[key])
+                if self.trackpad_pressed_required and button_data.get('trackpad_pressed', 0.0) < 0.5:
+                    val=0.0 
+                else:
+                    val = float(button_data[key])
 
                 # Create PointStamped message
                 p_msg = PointStamped()


### PR DESCRIPTION
Added teleoperation parameter "trackpad_pressed_required" (default false), this is used if you want to publish the trackpad values only if it is pressed.

Changed g1 launch accordingly